### PR TITLE
Corrected Dial Drift Behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,7 @@ dependencies = [
  "glium",
  "glutin",
  "hound",
+ "rand",
  "rodio",
  "serde",
 ]
@@ -1355,6 +1356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +1396,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,7 @@ egui_glium = "0.17.0"
 hound = "3.4"
 rodio = "0.15.0"
 serde = { version = "1.0", features = ["derive"] }
+rand = "0.8.5"
 
+[features]
+debugging = []

--- a/src/window.rs
+++ b/src/window.rs
@@ -6,7 +6,8 @@ use glutin::event::{ElementState, VirtualKeyCode};
 
 use crate::{
     dial::{
-        Dial, DialDrawData, DIALS_MAX_WIDTH_PERCENT, DIAL_HEIGHT_PERCENT, DIAL_Y_OFFSET_PERCENT,
+        Dial, DialDrawData, DialRange, DIALS_MAX_WIDTH_PERCENT, DIAL_HEIGHT_PERCENT,
+        DIAL_Y_OFFSET_PERCENT,
     },
     frame::Frame,
 };
@@ -44,7 +45,11 @@ pub fn draw_gui() {
     let mut dials = Vec::new();
 
     for i in 0..num_dials {
-        let dial = Dial::new(i + 1, (i + 1) as f32 * 100.0);
+        let dial = Dial::new(
+            i + 1,
+            25.0,
+            DialRange::new(i as f32 * 200.0, (i + 1) as f32 * 400.0),
+        );
         dials.push(dial);
     }
 
@@ -108,13 +113,14 @@ pub fn draw_gui() {
                         dial_width_percent,
                         window_width,
                         window_left_bottom,
-                        delta_time,
                     };
 
                     for dial in dials.iter_mut() {
+                        dial.update(delta_time);
                         dial.draw(painter, &dial_draw_data);
                     }
 
+                    // ----------------- Draw the frame -----------------
                     frame.update(&input_axes, delta_time);
                     frame.draw(painter, &window_rect, delta_time);
                 });


### PR DESCRIPTION
Now the dials can drift from any position in either direction, and keep track of their in-range zone.
The dials sound the alarm when they go out of range, and the user can reset them using the (for now hard-coded) 1-5