### PR TITLE
Finished input file io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Cargo.lock
 
 # Don't discriminate against Vim users
 *.vim
+
+config.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
  "rand",
  "rodio",
  "serde",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,10 @@ egui_glium = "0.17.0"
 
 hound = "3.4"
 rodio = "0.15.0"
-serde = { version = "1.0", features = ["derive"] }
+
 rand = "0.8.5"
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.5.9"
 
 [features]
 debugging = []

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,1 +1,122 @@
-pub struct A {}
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Serialize, Deserialize)]
+pub struct Config {
+    /// The name of the ball to use for this experient
+    pub active_ball: Option<String>,
+
+    /// Where the output data gets stored to once the experiment is done
+    pub output_data_path: Option<String>,
+
+    pub balls: Vec<Ball>,
+    pub dials: Vec<Dial>,
+    pub alarms: Vec<Alarm>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Ball {
+    pub name: String,
+    /// The action that this ball takes.
+    ///
+    /// Can be one of `random_direction`, `random_speed`, or `random_direction_change`
+    pub action: BallAction,
+
+    /// How quickly a ball configured for `random_direction_change` changes speed.
+    pub random_direction_change_time: Option<f64>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Dial {
+    /// The name of the alarm this dial uses
+    pub alarm: String,
+
+    pub start: f32,
+    pub end: f32,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Alarm {
+    /// The user defined name of this alarm. Used to match up which alarm is being used in
+    /// [`Dial::alarm`]
+    pub name: String,
+
+    /// The path to the audio file for this alarm
+    pub audio_path: String,
+
+    /// The key that clears this alarm.
+    /// Case insensitive single letter
+    pub clear_key: char,
+}
+
+pub enum BallAction {
+    /// The ball moves at a random speed
+    RandomSpeed,
+
+    /// The ball moves in a random direction from the crosshair
+    RandomDirection,
+
+    /// The ball changes directions randomly in a certain interval
+    RandomDirectionChange,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        let range_size = 4000.0;
+        Config {
+            balls: vec![Ball {
+                name: "Ball 1".to_owned(),
+                action: BallAction::RandomSpeed,
+                random_direction_change_time: Some(4.0),
+            }],
+            dials: (1u32..=5)
+                .map(|i| Dial {
+                    start: i as f32 * 200.0,
+                    end: i as f32 * 200.0 + range_size,
+                    alarm: i.to_string(),
+                })
+                .collect(),
+
+            alarms: (1u32..=5)
+                .map(|i| Alarm {
+                    name: i.to_string(),
+                    audio_path: "alarm.wav".to_owned(),
+                    clear_key: char::from_digit(i, 10).unwrap(),
+                })
+                .collect(),
+
+            active_ball: Some("Ball 1".to_owned()),
+            output_data_path: None,
+        }
+    }
+}
+
+impl Serialize for BallAction {
+    fn serialize<S>(&self, se: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = match self {
+            BallAction::RandomSpeed => "random_direction",
+            BallAction::RandomDirection => "random_speed",
+            BallAction::RandomDirectionChange => "random_direction_change",
+        };
+        s.serialize(se)
+    }
+}
+
+impl<'de> Deserialize<'de> for BallAction {
+    fn deserialize<D>(de: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(de)?;
+        match s.as_str() {
+            "random_direction" => Ok(BallAction::RandomDirection),
+            "random_speed" => Ok(BallAction::RandomSpeed),
+            "random_direction_change" => Ok(BallAction::RandomDirectionChange),
+            _ => Err(serde::de::Error::custom(format!(
+                "Unknown ball action `{s}`"
+            ))),
+        }
+    }
+}

--- a/src/dial.rs
+++ b/src/dial.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::{thread, time::Instant};
 
 use egui::{epaint::CircleShape, Color32, Pos2, Stroke};
@@ -23,7 +24,7 @@ const DIAL_NEEDLE_TICK_VALUE: f32 = 100.0;
 
 const DIAL_NEEDLE_MAX: f32 = DIAL_NEEDLE_TICK_VALUE * NUM_DIAL_TICKS as f32;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub struct DialRange {
     pub start: f32,
     pub end: f32,
@@ -54,7 +55,7 @@ pub struct DialDrawData {
 
 #[derive(Debug, Copy, Clone)]
 pub struct DialReaction {
-    pub dial_num: u32,
+    pub dial_id: usize,
     pub millis: u32,
     pub correct_key: bool,
     pub key: char,
@@ -62,15 +63,15 @@ pub struct DialReaction {
 
 #[derive(Debug, Copy, Clone)]
 pub struct DialAlarm {
-    pub dial_num: u32,
+    pub dial_id: usize,
     pub time: Instant,
     pub correct_key: char,
 }
 
 impl DialAlarm {
-    pub fn new(dial_num: u32, time: Instant, correct_key: char) -> Self {
+    pub fn new(dial_id: usize, time: Instant, correct_key: char) -> Self {
         Self {
-            dial_num,
+            dial_id,
             time,
             correct_key,
         }
@@ -78,9 +79,9 @@ impl DialAlarm {
 }
 
 impl DialReaction {
-    pub fn new(dial_num: u32, millis: u32, correct_key: bool, key: char) -> Self {
+    pub fn new(dial_id: usize, millis: u32, correct_key: bool, key: char) -> Self {
         Self {
-            dial_num,
+            dial_id,
             millis,
             correct_key,
             key,
@@ -91,7 +92,7 @@ impl DialReaction {
 #[derive(Debug, Copy, Clone)]
 pub struct Dial {
     value: f32,
-    dial_num: u32,
+    dial_id: usize,
     rate: f32,
     in_range: DialRange,
     key: char,
@@ -99,10 +100,10 @@ pub struct Dial {
 }
 
 impl Dial {
-    pub fn new(dial_num: u32, rate: f32, in_range: DialRange, key: char) -> Self {
+    pub fn new(dial_id: usize, rate: f32, in_range: DialRange, key: char) -> Self {
         let mut dial = Self {
             value: 0.0,
-            dial_num,
+            dial_id,
             rate,
             in_range,
             key,
@@ -138,7 +139,7 @@ impl Dial {
         if !self.alarm_fired && !self.in_range.contains(self.value) {
             self.on_out_of_range();
 
-            let dial_alarm = DialAlarm::new(self.dial_num, Instant::now(), self.key);
+            let dial_alarm = DialAlarm::new(self.dial_id, Instant::now(), self.key);
 
             Some(dial_alarm)
         } else {
@@ -148,7 +149,7 @@ impl Dial {
 
     pub fn draw(&mut self, painter: &egui::Painter, draw_data: &DialDrawData) {
         let dial_pos_x =
-            self.dial_num as f32 * draw_data.dial_width_percent * draw_data.window_width;
+            (self.dial_id + 1) as f32 * draw_data.dial_width_percent * draw_data.window_width;
         let dial_center = draw_data.window_left_bottom
             + Pos2::new(dial_pos_x, -draw_data.radius - draw_data.y_offset).to_vec2();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,14 +43,12 @@ fn validate_config(config: &mut config::Config) {
         }
     }
 
-    // We need to print `alarm_names` in the event of an error
-    #[allow(clippy::needless_collect)]
     let alarm_names: Vec<_> = config.alarms.iter().map(|b| &b.name).collect();
     for dial in &config.dials {
         let alarm_name = &dial.alarm;
         if !alarm_names.contains(&alarm_name) {
             println!("alarm `{alarm_name}` is missing");
-            println!("available alarms are {alarm_name:?}");
+            println!("available alarms are {alarm_names:?}");
             std::process::exit(1);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,48 +7,43 @@ mod window;
 pub mod audio;
 pub mod config;
 
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Config {
-    pub dials: Vec<Dial>,
-    pub balls: Vec<Ball>,
-    pub alarms: Vec<Alarm>,
-
     /// The name of the ball to use for this experient
     pub active_ball: Option<String>,
 
     /// Where the output data gets stored to once the experiment is done
-    #[serde(default = "out_path_default")]
-    pub output_data_path: String,
+    pub output_data_path: Option<String>,
+
+    pub balls: Vec<Ball>,
+    pub dials: Vec<Dial>,
+    pub alarms: Vec<Alarm>,
 }
 
-fn out_path_default() -> String {
-    "data.csv".into()
-}
-
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Ball {
     pub name: String,
     /// The action that this ball takes.
     ///
     /// Can be one of `random_direction`, `random_speed`, or `random_direction_change`
-    #[serde(deserialize_with = "de_action")]
     pub action: BallAction,
 
     /// How quickly a ball configured for `random_direction_change` changes speed.
     pub random_direction_change_time: Option<f64>,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Dial {
-    pub in_range_zone: f64,
-    pub out_of_range_zone: f64,
-    pub unit_step: f64,
+    /// The name of the alarm this dial uses
     pub alarm: String,
+
+    pub start: f32,
+    pub end: f32,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Alarm {
     /// The user defined name of this alarm. Used to match up which alarm is being used in
     /// [`Dial::alarm`]
@@ -58,8 +53,8 @@ pub struct Alarm {
     pub audio_path: String,
 
     /// The key that clears this alarm.
-    /// Case insensitive single letter or standard key code like `<Escape>`
-    pub clear_key: String,
+    /// Case insensitive single letter
+    pub clear_key: char,
 }
 
 pub enum BallAction {
@@ -73,21 +68,119 @@ pub enum BallAction {
     RandomDirectionChange,
 }
 
-fn de_action<'de, D>(de: D) -> Result<BallAction, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s = String::deserialize(de)?;
-    match s.as_str() {
-        "random_direction" => Ok(BallAction::RandomDirection),
-        "random_speed" => Ok(BallAction::RandomSpeed),
-        "random_direction_change" => Ok(BallAction::RandomDirectionChange),
-        _ => Err(serde::de::Error::custom(format!(
-            "Unknown ball action `{s}`"
-        ))),
+impl Serialize for BallAction {
+    fn serialize<S>(&self, se: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = match self {
+            BallAction::RandomSpeed => "random_direction",
+            BallAction::RandomDirection => "random_speed",
+            BallAction::RandomDirectionChange => "random_direction_change",
+        };
+        s.serialize(se)
     }
 }
 
+impl<'de> Deserialize<'de> for BallAction {
+    fn deserialize<D>(de: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(de)?;
+        match s.as_str() {
+            "random_direction" => Ok(BallAction::RandomDirection),
+            "random_speed" => Ok(BallAction::RandomSpeed),
+            "random_direction_change" => Ok(BallAction::RandomDirectionChange),
+            _ => Err(serde::de::Error::custom(format!(
+                "Unknown ball action `{s}`"
+            ))),
+        }
+    }
+}
+const DEFAULT_INPUT_PATH: &str = "./config.toml";
+
 pub fn run() {
-    window::draw_gui();
+    let mut config = match std::fs::read_to_string(DEFAULT_INPUT_PATH) {
+        Ok(toml) => match toml::from_str(&toml) {
+            Ok(t) => t,
+            Err(e) => {
+                panic!();
+            }
+        },
+        /*for i in 0..num_dials {
+            let dial = Dial::new(
+                i + 1,
+                50.0,
+                DialRange::new(i as f32 * 200.0, i as f32 * 200.0 + range_size),
+                (i + 1).to_string().chars().next().unwrap(),
+            );
+            dials.push(dial);
+        }*/
+        Err(_) => {
+            let range_size = 4000.0;
+            let config = Config {
+                balls: vec![Ball {
+                    name: "Ball 1".to_owned(),
+                    action: BallAction::RandomSpeed,
+                    random_direction_change_time: Some(4.0),
+                }],
+                dials: (1u32..=5)
+                    .map(|i| Dial {
+                        start: i as f32 * 200.0,
+                        end: i as f32 * 200.0 + range_size,
+                        alarm: i.to_string(),
+                    })
+                    .collect(),
+
+                alarms: (1u32..=5)
+                    .map(|i| Alarm {
+                        name: i.to_string(),
+                        audio_path: "alarm.wav".to_owned(),
+                        clear_key: char::from_digit(i, 10).unwrap(),
+                    })
+                    .collect(),
+
+                active_ball: Some("Ball 1".to_owned()),
+                output_data_path: None,
+            };
+            // Write out default config if none existed before
+            let toml = toml::to_string(&config).unwrap();
+            std::fs::write(DEFAULT_INPUT_PATH, &toml).unwrap();
+
+            config
+        }
+    };
+    validate_config(&mut config);
+
+    window::draw_gui(&config);
+}
+
+fn validate_config(config: &mut Config) {
+    if let Some(active) = &config.active_ball {
+        let ball_names: Vec<_> = config.balls.iter().map(|b| &b.name).collect();
+        if !ball_names.contains(&active) {
+            println!("active ball `{active}` is missing");
+            println!("available balls are {ball_names:?}");
+            std::process::exit(1);
+        }
+    }
+    let alarm_names: Vec<_> = config.alarms.iter().map(|b| &b.name).collect();
+    for dial in &config.dials {
+        let alarm_name = &dial.alarm;
+        if !alarm_names.contains(&alarm_name) {
+            println!("alarm `{alarm_name}` is missing");
+            println!("available alarms are {alarm_name:?}");
+            std::process::exit(1);
+        }
+    }
+    for alarm in &mut config.alarms {
+        alarm.clear_key = alarm
+            .clear_key
+            .to_uppercase()
+            .to_string()
+            .chars()
+            .next()
+            .unwrap();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,97 +7,6 @@ mod window;
 pub mod audio;
 pub mod config;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-#[derive(Serialize, Deserialize)]
-pub struct Config {
-    /// The name of the ball to use for this experient
-    pub active_ball: Option<String>,
-
-    /// Where the output data gets stored to once the experiment is done
-    pub output_data_path: Option<String>,
-
-    pub balls: Vec<Ball>,
-    pub dials: Vec<Dial>,
-    pub alarms: Vec<Alarm>,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct Ball {
-    pub name: String,
-    /// The action that this ball takes.
-    ///
-    /// Can be one of `random_direction`, `random_speed`, or `random_direction_change`
-    pub action: BallAction,
-
-    /// How quickly a ball configured for `random_direction_change` changes speed.
-    pub random_direction_change_time: Option<f64>,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct Dial {
-    /// The name of the alarm this dial uses
-    pub alarm: String,
-
-    pub start: f32,
-    pub end: f32,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct Alarm {
-    /// The user defined name of this alarm. Used to match up which alarm is being used in
-    /// [`Dial::alarm`]
-    pub name: String,
-
-    /// The path to the audio file for this alarm
-    pub audio_path: String,
-
-    /// The key that clears this alarm.
-    /// Case insensitive single letter
-    pub clear_key: char,
-}
-
-pub enum BallAction {
-    /// The ball moves at a random speed
-    RandomSpeed,
-
-    /// The ball moves in a random direction from the crosshair
-    RandomDirection,
-
-    /// The ball changes directions randomly in a certain interval
-    RandomDirectionChange,
-}
-
-impl Serialize for BallAction {
-    fn serialize<S>(&self, se: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let s = match self {
-            BallAction::RandomSpeed => "random_direction",
-            BallAction::RandomDirection => "random_speed",
-            BallAction::RandomDirectionChange => "random_direction_change",
-        };
-        s.serialize(se)
-    }
-}
-
-impl<'de> Deserialize<'de> for BallAction {
-    fn deserialize<D>(de: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(de)?;
-        match s.as_str() {
-            "random_direction" => Ok(BallAction::RandomDirection),
-            "random_speed" => Ok(BallAction::RandomSpeed),
-            "random_direction_change" => Ok(BallAction::RandomDirectionChange),
-            _ => Err(serde::de::Error::custom(format!(
-                "Unknown ball action `{s}`"
-            ))),
-        }
-    }
-}
 const DEFAULT_INPUT_PATH: &str = "./config.toml";
 
 pub fn run() {
@@ -105,46 +14,14 @@ pub fn run() {
         Ok(toml) => match toml::from_str(&toml) {
             Ok(t) => t,
             Err(e) => {
-                panic!();
+                println!("failed to parse config file");
+                println!("{}", e);
+                std::process::exit(1);
             }
         },
-        /*for i in 0..num_dials {
-            let dial = Dial::new(
-                i + 1,
-                50.0,
-                DialRange::new(i as f32 * 200.0, i as f32 * 200.0 + range_size),
-                (i + 1).to_string().chars().next().unwrap(),
-            );
-            dials.push(dial);
-        }*/
         Err(_) => {
-            let range_size = 4000.0;
-            let config = Config {
-                balls: vec![Ball {
-                    name: "Ball 1".to_owned(),
-                    action: BallAction::RandomSpeed,
-                    random_direction_change_time: Some(4.0),
-                }],
-                dials: (1u32..=5)
-                    .map(|i| Dial {
-                        start: i as f32 * 200.0,
-                        end: i as f32 * 200.0 + range_size,
-                        alarm: i.to_string(),
-                    })
-                    .collect(),
-
-                alarms: (1u32..=5)
-                    .map(|i| Alarm {
-                        name: i.to_string(),
-                        audio_path: "alarm.wav".to_owned(),
-                        clear_key: char::from_digit(i, 10).unwrap(),
-                    })
-                    .collect(),
-
-                active_ball: Some("Ball 1".to_owned()),
-                output_data_path: None,
-            };
             // Write out default config if none existed before
+            let config = config::Config::default();
             let toml = toml::to_string(&config).unwrap();
             std::fs::write(DEFAULT_INPUT_PATH, &toml).unwrap();
 
@@ -156,7 +33,7 @@ pub fn run() {
     window::draw_gui(&config);
 }
 
-fn validate_config(config: &mut Config) {
+fn validate_config(config: &mut config::Config) {
     if let Some(active) = &config.active_ball {
         let ball_names: Vec<_> = config.balls.iter().map(|b| &b.name).collect();
         if !ball_names.contains(&active) {
@@ -165,6 +42,9 @@ fn validate_config(config: &mut Config) {
             std::process::exit(1);
         }
     }
+
+    // We need to print `alarm_names` in the event of an error
+    #[allow(clippy::needless_collect)]
     let alarm_names: Vec<_> = config.alarms.iter().map(|b| &b.name).collect();
     for dial in &config.dials {
         let alarm_name = &dial.alarm;

--- a/src/window.rs
+++ b/src/window.rs
@@ -8,6 +8,7 @@ use glium::glutin;
 use glutin::event::{ElementState, VirtualKeyCode};
 
 use crate::{
+    config,
     dial::{
         Dial, DialDrawData, DialRange, DialReaction, DIALS_MAX_WIDTH_PERCENT, DIAL_HEIGHT_PERCENT,
         DIAL_Y_OFFSET_PERCENT,
@@ -36,8 +37,8 @@ fn create_display(event_loop: &glutin::event_loop::EventLoop<()>) -> glium::Disp
     glium::Display::new(window_builder, context_builder, event_loop).unwrap()
 }
 
-/// Map a key press `k` to to its dial number, or None if `k` is not a dial
-macro_rules! key_to_dial_num {
+/// Map a key press `k` to the `char` it corresponds with
+macro_rules! key_to_char {
     ($k:expr, $($case:path, $lit:literal),+) => {
         match $k {
             $($case => Some($lit),)+
@@ -47,7 +48,7 @@ macro_rules! key_to_dial_num {
 }
 
 //Draws the gui, window, images, labels etc...
-pub fn draw_gui(config: &crate::Config) {
+pub fn draw_gui(config: &config::Config) {
     let event_loop = glutin::event_loop::EventLoop::with_user_event();
     let display = create_display(&event_loop);
 
@@ -55,7 +56,7 @@ pub fn draw_gui(config: &crate::Config) {
     let mut egui_glium = egui_glium::EguiGlium::new(&display);
 
     // Maps alarm names to alarm structs
-    let alarms: HashMap<&str, &crate::Alarm> =
+    let alarms: HashMap<&str, &config::Alarm> =
         config.alarms.iter().map(|d| (d.name.as_str(), d)).collect();
 
     let mut dials: Vec<_> = config
@@ -247,7 +248,7 @@ pub fn draw_gui(config: &crate::Config) {
                                 k => {
                                     use VirtualKeyCode::*;
 
-                                    let maybe_dial = key_to_dial_num!(
+                                    let maybe_dial = key_to_char!(
                                         k, Key1, '1', Key2, '2', Key3, '3', Key4, '4', Key5, '5',
                                         Key6, '6', Key7, '7', Key8, '8', Key9, '9', A, 'A', B, 'B',
                                         C, 'C', D, 'D', E, 'E', F, 'F', G, 'G', H, 'H', I, 'I', J,


### PR DESCRIPTION
This PR adds support for setting the dial configuration from a toml file
Input is validated for valid options such as good dial references, valid enum settings, etc.

The following were changed:
* `dial_num` was refactored to `dial_id` everywhere. It is now 0 indexed and a usize to make for easy indexing into slices
* `dial::Dial`s are construed with data form the configurable `crate::Dial`
* A default `config.toml` is generated if none exists 

TODO (in other PR's):
1. Fix the cursor to the center and use input to move ball.
2. Have the ball respect the config in `config.toml` (random direction, random speed, etc.)
