### PR TITLE
Added dial drift rate to config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -30,8 +30,12 @@ pub struct Dial {
     /// The name of the alarm this dial uses
     pub alarm: String,
 
+    /// The start of the "in-range"
     pub start: f32,
+    /// The end of the "in-range"
     pub end: f32,
+    /// The rate at which the dial drifts
+    pub rate: f32,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -70,9 +74,10 @@ impl Default for Config {
             }],
             dials: (1u32..=5)
                 .map(|i| Dial {
+                    alarm: i.to_string(),
                     start: i as f32 * 200.0,
                     end: i as f32 * 200.0 + range_size,
-                    alarm: i.to_string(),
+                    rate: 50.0,
                 })
                 .collect(),
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -63,9 +63,14 @@ pub fn draw_gui(config: &config::Config) {
         .dials
         .iter()
         .enumerate()
-        .map(|(i, d)| {
-            let alarm = alarms[d.alarm.as_str()];
-            Dial::new(i, 50.0, DialRange::new(d.start, d.end), alarm.clear_key)
+        .map(|(id, dial)| {
+            let alarm = alarms[dial.alarm.as_str()];
+            Dial::new(
+                id,
+                dial.rate,
+                DialRange::new(dial.start, dial.end),
+                alarm.clear_key,
+            )
         })
         .collect();
 


### PR DESCRIPTION
Now you can specify dial rate as a float for how many units per second it drifts at.