### PR TITLE
Updated to GILrs 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,8 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "gilrs"
-version = "0.9.0"
-source = "git+https://gitlab.com/gilrs-project/gilrs?rev=0c84b5d6fda38ba6b2d0389334704f1bb8e21cd5#0c84b5d6fda38ba6b2d0389334704f1bb8e21cd5"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d0342acdc7b591d171212e17c9350ca02383b86d5f9af33c6e3598e03a6c57e"
 dependencies = [
  "fnv",
  "gilrs-core",
@@ -1091,8 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "gilrs-core"
-version = "0.4.1"
-source = "git+https://gitlab.com/gilrs-project/gilrs?rev=0c84b5d6fda38ba6b2d0389334704f1bb8e21cd5#0c84b5d6fda38ba6b2d0389334704f1bb8e21cd5"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6789d356476c3280a4e15365d23f62b4b4f1bcdac81fdd552f65807bce4666dd"
 dependencies = [
  "core-foundation",
  "io-kit-sys",
@@ -1100,12 +1102,12 @@ dependencies = [
  "libc",
  "libudev-sys",
  "log",
- "nix 0.24.3",
+ "nix 0.25.1",
  "uuid",
  "vec_map",
  "wasm-bindgen",
  "web-sys",
- "windows 0.42.0",
+ "windows 0.43.0",
 ]
 
 [[package]]
@@ -2873,6 +2875,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0286ba339aa753e70765d521bb0242cc48e1194562bfa2a2ad7ac8a6de28f5d5"
 dependencies = [
  "windows-implement",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
+dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc 0.42.1",
  "windows_i686_gnu 0.42.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0.63"
 derive-new = "0.5.9"
 eframe = "0.21.3"
 env_logger = "0.10.0"
-gilrs = {git = "https://gitlab.com/gilrs-project/gilrs", rev = "0c84b5d6fda38ba6b2d0389334704f1bb8e21cd5"}
+gilrs = "0.10.1"
 hound = "3.4"
 lazy_static = "1.4.0"
 log = "0.4.17"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,10 +245,10 @@ fn model(state: &Mutex<AppState>, audio: AudioManager) {
                     if let gilrs::ev::EventType::AxisChanged(axis, amount, _) = event {
                         match axis {
                             gilrs::ev::Axis::LeftStickX => {
-                                joystick_input_axes[1] = -amount;
+                                joystick_input_axes[0] = amount;
                             }
                             gilrs::ev::Axis::LeftStickY => {
-                                joystick_input_axes[0] = -amount;
+                                joystick_input_axes[1] = amount;
                             }
                             _ => {}
                         }


### PR DESCRIPTION
We can now use a regular version of GILrs instead of a git repo/commit. This version seems to have fixed the axes, although I had to un-correct our code so it reads it properly.